### PR TITLE
Fix type issue

### DIFF
--- a/src/HasExpandableMany.php
+++ b/src/HasExpandableMany.php
@@ -2,8 +2,8 @@
 
 namespace Lupennat\ExpandableMany;
 
-use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Fields\FieldCollection;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 trait HasExpandableMany
 {

--- a/src/HasExpandableMany.php
+++ b/src/HasExpandableMany.php
@@ -3,6 +3,7 @@
 namespace Lupennat\ExpandableMany;
 
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Fields\FieldCollection;
 
 trait HasExpandableMany
 {
@@ -11,7 +12,7 @@ trait HasExpandableMany
      *
      * @return \Laravel\Nova\Fields\FieldCollection<int, \Laravel\Nova\Fields\Field>
      */
-    public function indexFields(NovaRequest $request)
+    public function indexFields(NovaRequest $request): FieldCollection
     {
         return $this->availableFields($request)
             ->when($request->viaManyToMany(), $this->relatedFieldResolverCallback($request))


### PR DESCRIPTION
Fix the following error:

```
Declaration of Lupennat\ExpandableMany\HasExpandableMany::indexFields(Laravel\Nova\Http\Requests\NovaRequest $request) must be compatible with App\Nova\Resource::indexFields(Laravel\Nova\Http\Requests\NovaRequest $request): Laravel\Nova\Fields\FieldCollection
```